### PR TITLE
Agregando correctamente la funcionalidad de arbol_borrar

### DIFF
--- a/abb.c
+++ b/abb.c
@@ -68,8 +68,7 @@ nodo_abb_t* reemplazar_predecesor(nodo_abb_t* rama, nodo_abb_t* predecesor_hijo)
     if (!rama->derecha)
         return predecesor_hijo;
 
-    rama->derecha = remplazar_predecesor(rama->derecha, predecesor_hijo);
-
+    rama->derecha = reemplazar_predecesor(rama->derecha, predecesor_hijo);
     return rama;
 }
 


### PR DESCRIPTION
Transformando la función que se llama predecesor_inorden en dos funciones, predecesor_inorden que busca el nodo que es predecesor y otra funcion que se llama reemplazar predecesor que elimina del lugar al predecesor dejando su rama izquierda. 
Entre las dos funciones hacen lo que previamente hacía la funcion predecesor_inorden, lo cual no es bueno que una funcion tenga más de una funcionalidad